### PR TITLE
Adds support for Laravel 10 and drops lower than Laravel 8

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -17,11 +17,11 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '7.4'
+        php-version: '8.1'
 
     - name: Validate composer.json and composer.lock
       run: composer validate
-      
+
     - name: Cache Composer packages
       id: composer-cache
       uses: actions/cache@v2

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The first step in using the Zaengle Pipeline is to create a Data Traveler class.
 $traveler = (new RegisterTraveler())->setRequest(request()->all());
 ```
 
-While not required, by extending `Zaengle\Pipeline\Contracts\AbstractTraveler` you will inherit additional methods utilized in the `Zaengle\Pipeline\Pipeline` class.
+`Zaengle\Pipeline\Contracts\AbstractTraveler` provides additional methods utilized in the `Zaengle\Pipeline\Pipeline` class.
 
 ```php
 <?php
@@ -122,7 +122,7 @@ use App\User;
 use Zaengle\Pipeline\Contracts\PipeInterface;
 
 class CreateUser implements PipeInterface {
-    public function handle($traveler, \Closure $next)
+    public function handle(RegisterTraveler|AbstractTraveler $traveler, \Closure $next): RegisterTraveler
     {
         $traveler->setUser(
             User::create([
@@ -144,7 +144,7 @@ use Zaengle\Pipeline\Contracts\PipeInterface;
 
 class HandleMailingList implements PipeInterface
 {
-    public function handle($traveler, \Closure $next)
+    public function handle(RegisterTraveler|AbstractTraveler $traveler, \Closure $next): RegisterTraveler
     {
         if ($traveler->getRequest()->subscribe) {
             MailingService::subscribe($traveler->getUser()->email);
@@ -171,7 +171,7 @@ $response = app(Pipeline::class)->pipe($traveler, $pipes, $useTransactions = tru
 ```
 
 #### Results
-Assuming the traveler extends `AbstractTraveler`, after sending the `$traveler` through the data pipes you will have access to a `->passed()` method which indicates whether the pipeline completed successfully or not. 
+After sending the `$traveler` through the data pipes you will have access to a `->passed()` method which indicates whether the pipeline completed successfully or not. 
 
 ```php
 $response = app(Pipeline::class)->pipe($traveler, $pipes, $useTransactions = true);
@@ -187,7 +187,7 @@ if ($response->passed()) {
 }
 ```
 
-Extending `AbstractTraveler` also grants you access to the following convenience methods:
+`AbstractTraveler` grants you access to the following convenience methods:
 
  *`$response->passed()`*
  

--- a/composer.json
+++ b/composer.json
@@ -10,14 +10,14 @@
     }
   ],
   "require": {
-    "php": "^7.3|^8.0",
-    "illuminate/support": "5.*|6.*|7.*|8.*|9.*",
-    "illuminate/console": "5.*|6.*|7.*|8.*|9.*"
+    "php": "^8.1",
+    "illuminate/support": "8.*|9.*|10.*",
+    "illuminate/console": "8.*|9.*|10.*"
   },
   "require-dev": {
     "mockery/mockery": ">=0.9.9",
     "phpunit/phpunit": ">=4.1",
-    "orchestra/testbench": "~3.6.0|~3.7.0|~3.8.0"
+    "orchestra/testbench": "~8.0"
   },
   "autoload": {
     "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,16 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnError="false"
-         stopOnFailure="false"
-         verbose="true"
->
+<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        backupGlobals="false"
+        bootstrap="vendor/autoload.php"
+        colors="true"
+        processIsolation="false"
+        stopOnError="false"
+        stopOnFailure="false"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
+        cacheDirectory=".phpunit.cache"
+        backupStaticProperties="false">
   <testsuites>
     <testsuite name="Zaengle Pipeline Test Suite">
       <directory suffix="Test.php">./tests/</directory>

--- a/src/Contracts/AbstractTraveler.php
+++ b/src/Contracts/AbstractTraveler.php
@@ -2,91 +2,57 @@
 
 namespace Zaengle\Pipeline\Contracts;
 
-/**
- * Class AbstractTraveler.
- */
+use Exception;
+
 abstract class AbstractTraveler
 {
     const TRAVELER_SUCCESS = 'ok';
 
     const TRAVELER_FAIL = 'fail';
 
-    /**
-     * @var string
-     */
-    protected $status;
+    protected string $status;
 
-    /**
-     * @var string
-     */
-    protected $message = 'Traveler passed successfully.';
+    protected string $message = 'Traveler passed successfully.';
 
-    /**
-     * @var \Exception
-     */
-    protected $exception;
+    protected ?Exception $exception = null;
 
-    /**
-     * @param  mixed  $status
-     * @return AbstractTraveler
-     */
-    public function setStatus($status)
+    public function setStatus(string $status): AbstractTraveler
     {
         $this->status = $status;
 
         return $this;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getStatus()
+    public function getStatus(): string
     {
         return $this->status;
     }
 
-    /**
-     * @param  mixed  $message
-     * @return AbstractTraveler
-     */
-    public function setMessage($message)
+    public function setMessage(string $message): AbstractTraveler
     {
         $this->message = $message;
 
         return $this;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getMessage()
+    public function getMessage(): string
     {
         return $this->message;
     }
 
-    /**
-     * @param  mixed  $exception
-     * @return AbstractTraveler
-     */
-    public function setException($exception)
+    public function setException(Exception $exception): AbstractTraveler
     {
         $this->exception = $exception;
 
         return $this;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getException()
+    public function getException(): ?Exception
     {
         return $this->exception;
     }
 
-    /**
-     * @return bool
-     */
-    public function passed()
+    public function passed(): bool
     {
         return $this->getStatus() === self::TRAVELER_SUCCESS;
     }

--- a/src/Contracts/PipeInterface.php
+++ b/src/Contracts/PipeInterface.php
@@ -2,15 +2,9 @@
 
 namespace Zaengle\Pipeline\Contracts;
 
-/**
- * Interface PipeInterface.
- */
+use Closure;
+
 interface PipeInterface
 {
-    /**
-     * @param $traveler
-     * @param  \Closure  $next
-     * @return mixed
-     */
-    public function handle($traveler, \Closure $next);
+    public function handle(AbstractTraveler $traveler, Closure $next): AbstractTraveler;
 }

--- a/src/Example/ExamplePipeline.php
+++ b/src/Example/ExamplePipeline.php
@@ -5,17 +5,14 @@ namespace Zaengle\Pipeline\Example;
 use Zaengle\Pipeline\Example\Pipes\ExamplePipe;
 use Zaengle\Pipeline\Pipeline;
 
-/**
- * Class Example.
- */
 class ExamplePipeline
 {
     public function __invoke()
     {
         $traveler = (new ExampleTraveler())
-      ->setDemoData([
-          'name' => 'Zaengle',
-      ]);
+            ->setDemoData([
+                'name' => 'Zaengle',
+            ]);
 
         $pipes = [
             ExamplePipe::class,
@@ -27,9 +24,9 @@ class ExamplePipeline
             // Handle pass
         } else {
             // Handle fail
-      // $response->getException();
-      // $response->getMessage();
-      // $response->getStatus();
+            // $response->getException();
+            // $response->getMessage();
+            // $response->getStatus();
         }
     }
 }

--- a/src/Example/ExampleTraveler.php
+++ b/src/Example/ExampleTraveler.php
@@ -4,29 +4,16 @@ namespace Zaengle\Pipeline\Example;
 
 use Zaengle\Pipeline\Contracts\AbstractTraveler;
 
-/**
- * Class ExampleTraveler.
- */
 class ExampleTraveler extends AbstractTraveler
 {
-    /**
-     * @var mixed
-     */
-    private $demoData;
+    private array $demoData;
 
-    /**
-     * @return mixed
-     */
-    public function getDemoData()
+    public function getDemoData(): array
     {
         return $this->demoData;
     }
 
-    /**
-     * @param  mixed  $demoData
-     * @return ExampleTraveler
-     */
-    public function setDemoData($demoData)
+    public function setDemoData(array $demoData): ExampleTraveler
     {
         $this->demoData = $demoData;
 

--- a/src/Example/Pipes/ExamplePipe.php
+++ b/src/Example/Pipes/ExamplePipe.php
@@ -2,17 +2,14 @@
 
 namespace Zaengle\Pipeline\Example\Pipes;
 
+use Closure;
+use Zaengle\Pipeline\Contracts\AbstractTraveler;
 use Zaengle\Pipeline\Contracts\PipeInterface;
+use Zaengle\Pipeline\Example\ExampleTraveler;
 
-/**
- * Class ExamplePipe.
- */
 class ExamplePipe implements PipeInterface
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function handle($traveler, \Closure $next)
+    public function handle(ExampleTraveler|AbstractTraveler $traveler, Closure $next): AbstractTraveler
     {
         dump($traveler->getName());
 

--- a/src/Facade.php
+++ b/src/Facade.php
@@ -2,15 +2,12 @@
 
 namespace Zaengle\Pipeline;
 
-/**
- * Class Facade.
- */
 class Facade extends \Illuminate\Support\Facades\Facade
 {
     /**
      * {@inheritdoc}
      */
-    protected static function getFacadeAccessor()
+    protected static function getFacadeAccessor(): string
     {
         return 'pipeline';
     }

--- a/src/Pipeline.php
+++ b/src/Pipeline.php
@@ -17,7 +17,7 @@ class Pipeline
     }
 
     /**
-     * @param  AbstractTraveler $data
+     * @param  AbstractTraveler  $data
      * @param  array  $pipes
      * @param  bool  $useDatabaseTransactions
      * @return AbstractTraveler

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -2,47 +2,17 @@
 
 namespace Zaengle\Pipeline;
 
-/**
- * Class ServiceProvider.
- */
 class ServiceProvider extends \Illuminate\Support\ServiceProvider
 {
-    /**
-     * Indicates if loading of the provider is deferred.
-     *
-     * @var bool
-     */
-    protected $defer = false;
-
-    /**
-     * Bootstrap services.
-     *
-     * @return void
-     */
-    public function boot()
-    {
-        //
-    }
-
-    /**
-     * Register services.
-     *
-     * @return void
-     */
-    public function register()
+    public function register(): void
     {
         $this->app->bind('pipeline', function ($app) {
             return new Pipeline($app);
         });
     }
 
-    /**
-     * @return array
-     */
-    public function provides()
+    public function provides(): array
     {
-        return [
-            'pipeline',
-        ];
+        return ['pipeline'];
     }
 }

--- a/tests/PipelineTest.php
+++ b/tests/PipelineTest.php
@@ -7,9 +7,6 @@ use Zaengle\Pipeline\Pipeline;
 use Zaengle\Pipeline\Tests\Pipes\FailedTestPipe;
 use Zaengle\Pipeline\Tests\Pipes\TestPipe;
 
-/**
- * Class PipelineTest.
- */
 class PipelineTest extends PipelineTestCase
 {
     /** @test */
@@ -64,29 +61,27 @@ class PipelineTest extends PipelineTestCase
     public function it_uses_db_transactions_on_a_failed_run()
     {
         DB::shouldReceive('beginTransaction')
-      ->once()
-      ->andReturnSelf()
-      ->shouldReceive('rollback')
-      ->once();
+          ->once()
+          ->andReturnSelf()
+          ->shouldReceive('rollback')
+          ->once();
 
         app(Pipeline::class)->pipe(
-      new TestTraveler(),
-      [FailedTestPipe::class],
-      true
-    );
+          new TestTraveler(),
+          [FailedTestPipe::class],
+          true
+        );
     }
 
     /** @test */
-    public function it_works_with_vanilla_travelers()
+    public function it_does_not_work_with_vanilla_travelers()
     {
+        $this->expectException(\TypeError::class);
+
         $traveler = new \stdClass();
 
-        $pipes = [
-            TestPipe::class,
-        ];
+        $pipes = [TestPipe::class];
 
         $response = app(Pipeline::class)->pipe($traveler, $pipes);
-
-        $this->assertSame($traveler, $response);
     }
 }

--- a/tests/PipelineTestCase.php
+++ b/tests/PipelineTestCase.php
@@ -3,10 +3,8 @@
 namespace Zaengle\Pipeline\Tests;
 
 use Orchestra\Testbench\TestCase;
+use Zaengle\Pipeline\ServiceProvider;
 
-/**
- * Class PipelineTestCase.
- */
 class PipelineTestCase extends TestCase
 {
     protected function setUp(): void
@@ -14,20 +12,12 @@ class PipelineTestCase extends TestCase
         parent::setUp();
     }
 
-    /**
-     * @param  \Illuminate\Foundation\Application  $app
-     * @return array
-     */
-    protected function getPackageProviders($app)
+    protected function getPackageProviders($app): array
     {
-        return [\Zaengle\Pipeline\ServiceProvider::class];
+        return [ServiceProvider::class];
     }
 
-    /**
-     * @param  \Illuminate\Foundation\Application  $app
-     * @return array
-     */
-    protected function getPackageAliases($app)
+    protected function getPackageAliases($app): array
     {
         return ['Pipeline' => 'Zaengle\Pipeline\Facade'];
     }

--- a/tests/Pipes/FailedTestPipe.php
+++ b/tests/Pipes/FailedTestPipe.php
@@ -2,20 +2,15 @@
 
 namespace Zaengle\Pipeline\Tests\Pipes;
 
+use Closure;
+use Zaengle\Pipeline\Contracts\AbstractTraveler;
 use Zaengle\Pipeline\Contracts\PipeInterface;
+use Zaengle\Pipeline\Tests\TestTraveler;
 
-/**
- * Class FailedTestPipe.
- */
 class FailedTestPipe implements PipeInterface
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function handle($traveler, \Closure $next)
+    public function handle(TestTraveler|AbstractTraveler $traveler, Closure $next): AbstractTraveler
     {
         throw new \Exception('This Pipe Has Failed!!!');
-
-        return $next($traveler);
     }
 }

--- a/tests/Pipes/TestPipe.php
+++ b/tests/Pipes/TestPipe.php
@@ -2,17 +2,14 @@
 
 namespace Zaengle\Pipeline\Tests\Pipes;
 
+use Closure;
+use Zaengle\Pipeline\Contracts\AbstractTraveler;
 use Zaengle\Pipeline\Contracts\PipeInterface;
+use Zaengle\Pipeline\Tests\TestTraveler;
 
-/**
- * Class TestPipe.
- */
 class TestPipe implements PipeInterface
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function handle($traveler, \Closure $next)
+    public function handle(TestTraveler|AbstractTraveler $traveler, Closure $next): AbstractTraveler
     {
         return $next($traveler);
     }

--- a/tests/TestTraveler.php
+++ b/tests/TestTraveler.php
@@ -4,9 +4,6 @@ namespace Zaengle\Pipeline\Tests;
 
 use Zaengle\Pipeline\Contracts\AbstractTraveler;
 
-/**
- * Class TestTraveler.
- */
 class TestTraveler extends AbstractTraveler
 {
 }


### PR DESCRIPTION
This PR adds support for Laravel 10 and drops support for Laravel 7 and lower. It also updates the minimum PHP version to 8.1 and cleans up comments and typehints.