### PR TITLE
Add Laravel 13 and PHP 8.4 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,8 @@
     }
   ],
   "require": {
-    "php": "^8.1|^8.2|^8.3",
-    "illuminate/support": "8.*|9.*|10.*|11.*|12.*",
-    "illuminate/console": "8.*|9.*|10.*|11.*|12.*"
+    "php": "^8.1|^8.2|^8.3|^8.4",
+    "illuminate/support": "8.*|9.*|10.*|11.*|12.*|13.*"
   },
   "require-dev": {
     "mockery/mockery": ">=0.9.9",


### PR DESCRIPTION
  ## Summary

  - Adds `^8.4` to the PHP version constraint
  - Adds `13.*` to the `illuminate/support` version constraint
  - Removes the unused `illuminate/console` requirement (no imports in `src/`)
